### PR TITLE
Rebrand color scheme from gold to dark red theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,20 +4,24 @@
 
 <div align="center">
 
-<img src="https://capsule-render.vercel.app/api?type=waving&color=0:0D1117,50:1A1A1A,100:FFD700&height=260&section=header&text=PRITAM%20PAWAR&fontSize=72&fontColor=FFD700&animation=fadeIn&fontAlignY=38" alt="banner" />
+<img src="https://capsule-render.vercel.app/api?type=waving&color=0:0D0000,30:1A0000,70:4A0000,100:CC0000&height=260&section=header&text=PRITAM%20PAWAR&fontSize=72&fontColor=CC0000&animation=fadeIn&fontAlignY=38" alt="banner" />
 
 <h3>🦇 &nbsp; <em>Gotham's Full-Stack Vigilante</em> &nbsp; 🦇</h3>
 <h4><em>Founder · Builder in the Shadows · I ship products, not pitches.</em></h4>
 
 <a href="https://pritampawar.com">
-  <img src="https://readme-typing-svg.demolab.com/?lines=I%27m+Vengeance.+I%27m+the+Night.;I%27m+a+Full-Stack+Engineer.;Founder+%40+Alkemii+Labs;Ex-Sprinklr+%C2%B7+NIT+Allahabad&font=Fira%20Code&center=true&width=620&height=50&color=FFD700&vCenter=true&pause=1000&size=22" alt="typing" />
+  <img src="https://readme-typing-svg.demolab.com/?lines=I%27m+Vengeance.+I%27m+the+Night.;I%27m+a+Full-Stack+Engineer.;Founder+%40+Alkemii+Labs;Ex-Sprinklr+%C2%B7+NIT+Allahabad&font=Fira%20Code&center=true&width=620&height=50&color=CC0000&vCenter=true&pause=1000&size=22" alt="typing" />
 </a>
 
 <br/>
 
-<img src="https://komarev.com/ghpvc/?username=pritamp17&label=PROFILE+VIEWS&color=FFD700&style=for-the-badge&labelColor=0D1117" alt="views" />
-<img src="https://img.shields.io/badge/Base-Gotham%2C%20India-FFD700?style=for-the-badge&labelColor=0D1117&logo=googlemaps&logoColor=FFD700" alt="location" />
-<img src="https://img.shields.io/badge/Status-On%20The%20Hunt-E50914?style=for-the-badge&labelColor=0D1117" alt="status" />
+<img src="https://komarev.com/ghpvc/?username=pritamp17&label=PROFILE+VIEWS&color=CC0000&style=for-the-badge&labelColor=0D0000" alt="views" />
+<img src="https://img.shields.io/badge/Base-Gotham%2C%20India-CC0000?style=for-the-badge&labelColor=0D0000&logo=googlemaps&logoColor=CC0000" alt="location" />
+<img src="https://img.shields.io/badge/Status-On%20The%20Hunt-E50914?style=for-the-badge&labelColor=0D0000" alt="status" />
+
+<br/><br/>
+
+<img src="rain.svg" width="900" alt="rain" />
 
 </div>
 
@@ -66,47 +70,47 @@ Full-stack engineer turned founder. I build products **end-to-end** — from sys
 
 **`LANGUAGES`**
 
-![Java](https://img.shields.io/badge/-JAVA-0D1117?style=for-the-badge&logo=openjdk&logoColor=FFD700)
-![TypeScript](https://img.shields.io/badge/-TYPESCRIPT-0D1117?style=for-the-badge&logo=typescript&logoColor=3178C6)
-![Python](https://img.shields.io/badge/-PYTHON-0D1117?style=for-the-badge&logo=python&logoColor=FFD43B)
-![Kotlin](https://img.shields.io/badge/-KOTLIN-0D1117?style=for-the-badge&logo=kotlin&logoColor=A97BFF)
-![C++](https://img.shields.io/badge/-C%2B%2B-0D1117?style=for-the-badge&logo=cplusplus&logoColor=00599C)
+![Java](https://img.shields.io/badge/-JAVA-0D0000?style=for-the-badge&logo=openjdk&logoColor=CC0000)
+![TypeScript](https://img.shields.io/badge/-TYPESCRIPT-0D0000?style=for-the-badge&logo=typescript&logoColor=3178C6)
+![Python](https://img.shields.io/badge/-PYTHON-0D0000?style=for-the-badge&logo=python&logoColor=FFD43B)
+![Kotlin](https://img.shields.io/badge/-KOTLIN-0D0000?style=for-the-badge&logo=kotlin&logoColor=A97BFF)
+![C++](https://img.shields.io/badge/-C%2B%2B-0D0000?style=for-the-badge&logo=cplusplus&logoColor=00599C)
 
 **`BACKEND`**
 
-![Spring Boot](https://img.shields.io/badge/-SPRING%20BOOT-0D1117?style=for-the-badge&logo=springboot&logoColor=6DB33F)
-![FastAPI](https://img.shields.io/badge/-FASTAPI-0D1117?style=for-the-badge&logo=fastapi&logoColor=009688)
-![Flask](https://img.shields.io/badge/-FLASK-0D1117?style=for-the-badge&logo=flask&logoColor=FFD700)
-![Kafka](https://img.shields.io/badge/-KAFKA-0D1117?style=for-the-badge&logo=apachekafka&logoColor=FFD700)
-![Elasticsearch](https://img.shields.io/badge/-ELASTICSEARCH-0D1117?style=for-the-badge&logo=elasticsearch&logoColor=FEC514)
+![Spring Boot](https://img.shields.io/badge/-SPRING%20BOOT-0D0000?style=for-the-badge&logo=springboot&logoColor=6DB33F)
+![FastAPI](https://img.shields.io/badge/-FASTAPI-0D0000?style=for-the-badge&logo=fastapi&logoColor=009688)
+![Flask](https://img.shields.io/badge/-FLASK-0D0000?style=for-the-badge&logo=flask&logoColor=CC0000)
+![Kafka](https://img.shields.io/badge/-KAFKA-0D0000?style=for-the-badge&logo=apachekafka&logoColor=CC0000)
+![Elasticsearch](https://img.shields.io/badge/-ELASTICSEARCH-0D0000?style=for-the-badge&logo=elasticsearch&logoColor=CC0000)
 
 **`FRONTEND`**
 
-![Next.js](https://img.shields.io/badge/-NEXT.JS-0D1117?style=for-the-badge&logo=nextdotjs&logoColor=FFD700)
-![React](https://img.shields.io/badge/-REACT-0D1117?style=for-the-badge&logo=react&logoColor=61DAFB)
-![React Native](https://img.shields.io/badge/-REACT%20NATIVE-0D1117?style=for-the-badge&logo=react&logoColor=61DAFB)
-![Expo](https://img.shields.io/badge/-EXPO-0D1117?style=for-the-badge&logo=expo&logoColor=FFD700)
+![Next.js](https://img.shields.io/badge/-NEXT.JS-0D0000?style=for-the-badge&logo=nextdotjs&logoColor=CC0000)
+![React](https://img.shields.io/badge/-REACT-0D0000?style=for-the-badge&logo=react&logoColor=61DAFB)
+![React Native](https://img.shields.io/badge/-REACT%20NATIVE-0D0000?style=for-the-badge&logo=react&logoColor=61DAFB)
+![Expo](https://img.shields.io/badge/-EXPO-0D0000?style=for-the-badge&logo=expo&logoColor=CC0000)
 
 **`DATA`**
 
-![MongoDB](https://img.shields.io/badge/-MONGODB-0D1117?style=for-the-badge&logo=mongodb&logoColor=47A248)
-![PostgreSQL](https://img.shields.io/badge/-POSTGRESQL-0D1117?style=for-the-badge&logo=postgresql&logoColor=4169E1)
-![Redis](https://img.shields.io/badge/-REDIS-0D1117?style=for-the-badge&logo=redis&logoColor=DC382D)
-![Vector Search](https://img.shields.io/badge/-VECTOR%20SEARCH-0D1117?style=for-the-badge&logo=databricks&logoColor=FFD700)
+![MongoDB](https://img.shields.io/badge/-MONGODB-0D0000?style=for-the-badge&logo=mongodb&logoColor=47A248)
+![PostgreSQL](https://img.shields.io/badge/-POSTGRESQL-0D0000?style=for-the-badge&logo=postgresql&logoColor=4169E1)
+![Redis](https://img.shields.io/badge/-REDIS-0D0000?style=for-the-badge&logo=redis&logoColor=DC382D)
+![Vector Search](https://img.shields.io/badge/-VECTOR%20SEARCH-0D0000?style=for-the-badge&logo=databricks&logoColor=CC0000)
 
 **`INFRA`**
 
-![AWS](https://img.shields.io/badge/-AWS-0D1117?style=for-the-badge&logo=amazonaws&logoColor=FFD700)
-![Docker](https://img.shields.io/badge/-DOCKER-0D1117?style=for-the-badge&logo=docker&logoColor=2496ED)
-![Google Cloud](https://img.shields.io/badge/-GCP-0D1117?style=for-the-badge&logo=googlecloud&logoColor=4285F4)
-![Supabase](https://img.shields.io/badge/-SUPABASE-0D1117?style=for-the-badge&logo=supabase&logoColor=3ECF8E)
+![AWS](https://img.shields.io/badge/-AWS-0D0000?style=for-the-badge&logo=amazonaws&logoColor=CC0000)
+![Docker](https://img.shields.io/badge/-DOCKER-0D0000?style=for-the-badge&logo=docker&logoColor=2496ED)
+![Google Cloud](https://img.shields.io/badge/-GCP-0D0000?style=for-the-badge&logo=googlecloud&logoColor=4285F4)
+![Supabase](https://img.shields.io/badge/-SUPABASE-0D0000?style=for-the-badge&logo=supabase&logoColor=3ECF8E)
 
 **`AI / ML`**
 
-![Gemini](https://img.shields.io/badge/-GEMINI%20API-0D1117?style=for-the-badge&logo=googlegemini&logoColor=FFD700)
-![RAG](https://img.shields.io/badge/-RAG%20PIPELINES-0D1117?style=for-the-badge&logo=openai&logoColor=FFD700)
-![WebGPU](https://img.shields.io/badge/-WEBGPU-0D1117?style=for-the-badge&logo=webgpu&logoColor=FFD700)
-![WebCodecs](https://img.shields.io/badge/-WEBCODECS-0D1117?style=for-the-badge&logo=mdnwebdocs&logoColor=FFD700)
+![Gemini](https://img.shields.io/badge/-GEMINI%20API-0D0000?style=for-the-badge&logo=googlegemini&logoColor=CC0000)
+![RAG](https://img.shields.io/badge/-RAG%20PIPELINES-0D0000?style=for-the-badge&logo=openai&logoColor=CC0000)
+![WebGPU](https://img.shields.io/badge/-WEBGPU-0D0000?style=for-the-badge&logo=webgpu&logoColor=CC0000)
+![WebCodecs](https://img.shields.io/badge/-WEBCODECS-0D0000?style=for-the-badge&logo=mdnwebdocs&logoColor=CC0000)
 
 </div>
 
@@ -149,12 +153,12 @@ Full-stack engineer turned founder. I build products **end-to-end** — from sys
 
 <div align="center">
 
-<img height="180" src="https://github-readme-stats.vercel.app/api?username=pritamp17&show_icons=true&count_private=true&hide_border=false&bg_color=0D1117&title_color=FFD700&icon_color=FFD700&text_color=C9D1D9&border_color=30363D" alt="stats" />
-<img height="180" src="https://github-readme-stats.vercel.app/api/top-langs/?username=pritamp17&layout=compact&hide_border=false&bg_color=0D1117&title_color=FFD700&text_color=C9D1D9&border_color=30363D" alt="top-langs" />
+<img height="180" src="https://github-readme-stats.vercel.app/api?username=pritamp17&show_icons=true&count_private=true&hide_border=false&bg_color=0D0000&title_color=CC0000&icon_color=CC0000&text_color=C9D1D9&border_color=3D0000" alt="stats" />
+<img height="180" src="https://github-readme-stats.vercel.app/api/top-langs/?username=pritamp17&layout=compact&hide_border=false&bg_color=0D0000&title_color=CC0000&text_color=C9D1D9&border_color=3D0000" alt="top-langs" />
 
 <br/><br/>
 
-<img src="https://github-readme-streak-stats.herokuapp.com/?user=pritamp17&theme=dark&background=0D1117&border=30363D&stroke=30363D&ring=FFD700&fire=FFD700&currStreakLabel=FFD700&sideLabels=C9D1D9&dates=C9D1D9" alt="streak" />
+<img src="https://github-readme-streak-stats.herokuapp.com/?user=pritamp17&theme=dark&background=0D0000&border=3D0000&stroke=3D0000&ring=CC0000&fire=CC0000&currStreakLabel=CC0000&sideLabels=C9D1D9&dates=C9D1D9" alt="streak" />
 
 </div>
 
@@ -165,16 +169,16 @@ Full-stack engineer turned founder. I build products **end-to-end** — from sys
 
 <div align="center">
 
-<a href="https://pritampawar.com"><img src="https://img.shields.io/badge/-pritampawar.com-FFD700?style=for-the-badge&logo=googlechrome&logoColor=0D1117&labelColor=0D1117" alt="website" /></a>
-<a href="https://alkemiilabs.com"><img src="https://img.shields.io/badge/-alkemiilabs.com-FFD700?style=for-the-badge&logo=openai&logoColor=0D1117&labelColor=0D1117" alt="alkemii" /></a>
-<a href="https://tournahub.net"><img src="https://img.shields.io/badge/-tournahub.net-FFD700?style=for-the-badge&logo=controller&logoColor=0D1117&labelColor=0D1117" alt="tournahub" /></a>
+<a href="https://pritampawar.com"><img src="https://img.shields.io/badge/-pritampawar.com-CC0000?style=for-the-badge&logo=googlechrome&logoColor=0D0000&labelColor=0D0000" alt="website" /></a>
+<a href="https://alkemiilabs.com"><img src="https://img.shields.io/badge/-alkemiilabs.com-CC0000?style=for-the-badge&logo=openai&logoColor=0D0000&labelColor=0D0000" alt="alkemii" /></a>
+<a href="https://tournahub.net"><img src="https://img.shields.io/badge/-tournahub.net-CC0000?style=for-the-badge&logo=controller&logoColor=0D0000&labelColor=0D0000" alt="tournahub" /></a>
 
 <br/>
 
-<a href="https://linkedin.com/in/pritam-pawar-070788197/"><img src="https://img.shields.io/badge/-LinkedIn-0A66C2?style=for-the-badge&logo=linkedin&logoColor=white&labelColor=0D1117" alt="linkedin" /></a>
-<a href="https://instagram.com/pritam_17__/"><img src="https://img.shields.io/badge/-Instagram-E4405F?style=for-the-badge&logo=instagram&logoColor=white&labelColor=0D1117" alt="instagram" /></a>
-<a href="https://discord.com/"><img src="https://img.shields.io/badge/-Discord-5865F2?style=for-the-badge&logo=discord&logoColor=white&labelColor=0D1117" alt="discord" /></a>
-<a href="mailto:pritampawar526@gmail.com"><img src="https://img.shields.io/badge/-Email-E50914?style=for-the-badge&logo=gmail&logoColor=white&labelColor=0D1117" alt="email" /></a>
+<a href="https://linkedin.com/in/pritam-pawar-070788197/"><img src="https://img.shields.io/badge/-LinkedIn-0A66C2?style=for-the-badge&logo=linkedin&logoColor=white&labelColor=0D0000" alt="linkedin" /></a>
+<a href="https://instagram.com/pritam_17__/"><img src="https://img.shields.io/badge/-Instagram-E4405F?style=for-the-badge&logo=instagram&logoColor=white&labelColor=0D0000" alt="instagram" /></a>
+<a href="https://discord.com/"><img src="https://img.shields.io/badge/-Discord-5865F2?style=for-the-badge&logo=discord&logoColor=white&labelColor=0D0000" alt="discord" /></a>
+<a href="mailto:pritampawar526@gmail.com"><img src="https://img.shields.io/badge/-Email-E50914?style=for-the-badge&logo=gmail&logoColor=white&labelColor=0D0000" alt="email" /></a>
 
 </div>
 
@@ -193,4 +197,4 @@ Full-stack engineer turned founder. I build products **end-to-end** — from sys
 
 </div>
 
-<img src="https://capsule-render.vercel.app/api?type=waving&color=0:FFD700,50:1A1A1A,100:0D1117&height=140&section=footer" alt="footer" />
+<img src="https://capsule-render.vercel.app/api?type=waving&color=0:CC0000,50:1A0000,100:0D0000&height=140&section=footer" alt="footer" />

--- a/rain.svg
+++ b/rain.svg
@@ -1,0 +1,83 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 120" width="900" height="120">
+  <rect width="900" height="120" fill="#0A0000"/>
+  <defs>
+    <style>
+      .d { stroke: #CC0000; stroke-linecap: round; }
+      @keyframes fall {
+        0%   { transform: translate(0px, -30px); opacity: 0; }
+        8%   { opacity: 0.65; }
+        92%  { opacity: 0.65; }
+        100% { transform: translate(-10px, 152px); opacity: 0; }
+      }
+    </style>
+  </defs>
+
+  <!-- Row 1: 55 rain drops with staggered durations & delays -->
+  <line class="d" x1="15"  y1="0" x2="8"  y2="18" stroke-width="1.5" style="animation:fall 1.1s -2.3s linear infinite"/>
+  <line class="d" x1="33"  y1="0" x2="28" y2="14" stroke-width="1.0" style="animation:fall 0.9s -0.7s linear infinite"/>
+  <line class="d" x1="50"  y1="0" x2="42" y2="20" stroke-width="2.0" style="animation:fall 1.3s -1.5s linear infinite"/>
+  <line class="d" x1="68"  y1="0" x2="62" y2="16" stroke-width="1.5" style="animation:fall 1.0s -0.2s linear infinite"/>
+  <line class="d" x1="85"  y1="0" x2="80" y2="12" stroke-width="1.0" style="animation:fall 0.8s -2.8s linear infinite"/>
+  <line class="d" x1="102" y1="0" x2="94" y2="19" stroke-width="1.5" style="animation:fall 1.2s -1.1s linear infinite"/>
+  <line class="d" x1="118" y1="0" x2="109" y2="22" stroke-width="2.0" style="animation:fall 1.4s -0.5s linear infinite"/>
+  <line class="d" x1="135" y1="0" x2="129" y2="15" stroke-width="1.0" style="animation:fall 0.9s -1.9s linear infinite"/>
+  <line class="d" x1="152" y1="0" x2="145" y2="17" stroke-width="1.5" style="animation:fall 1.1s -2.6s linear infinite"/>
+  <line class="d" x1="168" y1="0" x2="163" y2="13" stroke-width="1.0" style="animation:fall 0.8s -0.3s linear infinite"/>
+  <line class="d" x1="185" y1="0" x2="177" y2="21" stroke-width="2.0" style="animation:fall 1.3s -1.7s linear infinite"/>
+  <line class="d" x1="202" y1="0" x2="196" y2="16" stroke-width="1.5" style="animation:fall 1.0s -0.9s linear infinite"/>
+  <line class="d" x1="218" y1="0" x2="210" y2="19" stroke-width="1.5" style="animation:fall 1.2s -2.1s linear infinite"/>
+  <line class="d" x1="235" y1="0" x2="230" y2="14" stroke-width="1.0" style="animation:fall 0.9s -1.3s linear infinite"/>
+  <line class="d" x1="252" y1="0" x2="243" y2="22" stroke-width="2.0" style="animation:fall 1.4s -0.6s linear infinite"/>
+  <line class="d" x1="268" y1="0" x2="261" y2="17" stroke-width="1.5" style="animation:fall 1.1s -2.8s linear infinite"/>
+  <line class="d" x1="285" y1="0" x2="280" y2="12" stroke-width="1.0" style="animation:fall 0.8s -0.4s linear infinite"/>
+  <line class="d" x1="302" y1="0" x2="294" y2="20" stroke-width="2.0" style="animation:fall 1.3s -1.6s linear infinite"/>
+  <line class="d" x1="318" y1="0" x2="312" y2="16" stroke-width="1.5" style="animation:fall 1.0s -2.4s linear infinite"/>
+  <line class="d" x1="335" y1="0" x2="329" y2="15" stroke-width="1.0" style="animation:fall 0.9s -0.8s linear infinite"/>
+  <line class="d" x1="352" y1="0" x2="344" y2="19" stroke-width="1.5" style="animation:fall 1.2s -1.2s linear infinite"/>
+  <line class="d" x1="368" y1="0" x2="359" y2="22" stroke-width="2.0" style="animation:fall 1.4s -2.7s linear infinite"/>
+  <line class="d" x1="385" y1="0" x2="380" y2="13" stroke-width="1.0" style="animation:fall 0.8s -0.5s linear infinite"/>
+  <line class="d" x1="402" y1="0" x2="395" y2="17" stroke-width="1.5" style="animation:fall 1.1s -1.8s linear infinite"/>
+  <line class="d" x1="418" y1="0" x2="410" y2="21" stroke-width="2.0" style="animation:fall 1.3s -2.2s linear infinite"/>
+  <line class="d" x1="435" y1="0" x2="429" y2="14" stroke-width="1.0" style="animation:fall 0.9s -0.6s linear infinite"/>
+  <line class="d" x1="452" y1="0" x2="446" y2="16" stroke-width="1.5" style="animation:fall 1.0s -1.4s linear infinite"/>
+  <line class="d" x1="468" y1="0" x2="460" y2="19" stroke-width="1.5" style="animation:fall 1.2s -2.5s linear infinite"/>
+  <line class="d" x1="485" y1="0" x2="476" y2="22" stroke-width="2.0" style="animation:fall 1.4s -0.3s linear infinite"/>
+  <line class="d" x1="502" y1="0" x2="497" y2="12" stroke-width="1.0" style="animation:fall 0.8s -1.9s linear infinite"/>
+  <line class="d" x1="518" y1="0" x2="511" y2="18" stroke-width="1.5" style="animation:fall 1.1s -0.7s linear infinite"/>
+  <line class="d" x1="535" y1="0" x2="527" y2="20" stroke-width="2.0" style="animation:fall 1.3s -2.3s linear infinite"/>
+  <line class="d" x1="552" y1="0" x2="546" y2="15" stroke-width="1.0" style="animation:fall 0.9s -1.0s linear infinite"/>
+  <line class="d" x1="568" y1="0" x2="562" y2="16" stroke-width="1.5" style="animation:fall 1.0s -2.8s linear infinite"/>
+  <line class="d" x1="585" y1="0" x2="577" y2="19" stroke-width="1.5" style="animation:fall 1.2s -0.4s linear infinite"/>
+  <line class="d" x1="602" y1="0" x2="593" y2="22" stroke-width="2.0" style="animation:fall 1.4s -1.6s linear infinite"/>
+  <line class="d" x1="618" y1="0" x2="613" y2="12" stroke-width="1.0" style="animation:fall 0.8s -2.1s linear infinite"/>
+  <line class="d" x1="635" y1="0" x2="628" y2="17" stroke-width="1.5" style="animation:fall 1.1s -0.9s linear infinite"/>
+  <line class="d" x1="652" y1="0" x2="644" y2="21" stroke-width="2.0" style="animation:fall 1.3s -1.3s linear infinite"/>
+  <line class="d" x1="668" y1="0" x2="662" y2="14" stroke-width="1.0" style="animation:fall 0.9s -2.6s linear infinite"/>
+  <line class="d" x1="685" y1="0" x2="679" y2="16" stroke-width="1.5" style="animation:fall 1.0s -0.2s linear infinite"/>
+  <line class="d" x1="702" y1="0" x2="694" y2="19" stroke-width="1.5" style="animation:fall 1.2s -1.8s linear infinite"/>
+  <line class="d" x1="718" y1="0" x2="709" y2="22" stroke-width="2.0" style="animation:fall 1.4s -2.4s linear infinite"/>
+  <line class="d" x1="735" y1="0" x2="730" y2="13" stroke-width="1.0" style="animation:fall 0.8s -0.6s linear infinite"/>
+  <line class="d" x1="752" y1="0" x2="745" y2="18" stroke-width="1.5" style="animation:fall 1.1s -1.1s linear infinite"/>
+  <line class="d" x1="768" y1="0" x2="760" y2="20" stroke-width="2.0" style="animation:fall 1.3s -2.9s linear infinite"/>
+  <line class="d" x1="785" y1="0" x2="779" y2="15" stroke-width="1.0" style="animation:fall 0.9s -0.5s linear infinite"/>
+  <line class="d" x1="802" y1="0" x2="796" y2="16" stroke-width="1.5" style="animation:fall 1.0s -1.7s linear infinite"/>
+  <line class="d" x1="818" y1="0" x2="810" y2="19" stroke-width="1.5" style="animation:fall 1.2s -2.2s linear infinite"/>
+  <line class="d" x1="835" y1="0" x2="826" y2="22" stroke-width="2.0" style="animation:fall 1.4s -0.8s linear infinite"/>
+  <line class="d" x1="852" y1="0" x2="847" y2="12" stroke-width="1.0" style="animation:fall 0.8s -1.4s linear infinite"/>
+  <line class="d" x1="868" y1="0" x2="861" y2="17" stroke-width="1.5" style="animation:fall 1.1s -2.7s linear infinite"/>
+  <line class="d" x1="885" y1="0" x2="877" y2="21" stroke-width="2.0" style="animation:fall 1.3s -0.3s linear infinite"/>
+
+  <!-- Lighter secondary layer for depth -->
+  <line class="d" x1="24"  y1="0" x2="18"  y2="15" stroke-width="0.8" style="animation:fall 1.0s -1.5s linear infinite;opacity:0.35"/>
+  <line class="d" x1="75"  y1="0" x2="70"  y2="18" stroke-width="0.8" style="animation:fall 1.2s -2.0s linear infinite;opacity:0.35"/>
+  <line class="d" x1="140" y1="0" x2="135" y2="14" stroke-width="0.8" style="animation:fall 0.9s -0.9s linear infinite;opacity:0.35"/>
+  <line class="d" x1="225" y1="0" x2="219" y2="17" stroke-width="0.8" style="animation:fall 1.1s -2.5s linear infinite;opacity:0.35"/>
+  <line class="d" x1="310" y1="0" x2="304" y2="16" stroke-width="0.8" style="animation:fall 1.3s -0.6s linear infinite;opacity:0.35"/>
+  <line class="d" x1="395" y1="0" x2="389" y2="19" stroke-width="0.8" style="animation:fall 0.8s -1.8s linear infinite;opacity:0.35"/>
+  <line class="d" x1="480" y1="0" x2="474" y2="15" stroke-width="0.8" style="animation:fall 1.2s -2.9s linear infinite;opacity:0.35"/>
+  <line class="d" x1="565" y1="0" x2="559" y2="18" stroke-width="0.8" style="animation:fall 1.0s -0.3s linear infinite;opacity:0.35"/>
+  <line class="d" x1="648" y1="0" x2="642" y2="14" stroke-width="0.8" style="animation:fall 1.4s -1.6s linear infinite;opacity:0.35"/>
+  <line class="d" x1="732" y1="0" x2="726" y2="20" stroke-width="0.8" style="animation:fall 0.9s -2.2s linear infinite;opacity:0.35"/>
+  <line class="d" x1="820" y1="0" x2="814" y2="16" stroke-width="0.8" style="animation:fall 1.1s -0.8s linear infinite;opacity:0.35"/>
+  <line class="d" x1="875" y1="0" x2="869" y2="13" stroke-width="0.8" style="animation:fall 1.3s -1.4s linear infinite;opacity:0.35"/>
+</svg>


### PR DESCRIPTION
## Summary
Updated the README profile to transition from a gold/yellow color scheme to a dark red/crimson theme, aligning with a more dramatic "Gotham" aesthetic. This includes comprehensive color updates across all badges, stats cards, and visual elements, plus the addition of an animated rain effect SVG.

## Key Changes
- **Color palette migration**: Replaced all gold accents (`#FFD700`) with dark red (`#CC0000`) and updated background colors from `#0D1117` to `#0D0000` for deeper blacks
- **Banner and header updates**: Modified the main banner gradient and typing animation colors to use the new red theme
- **Badge styling**: Updated all technology stack badges (Languages, Backend, Frontend, Data, Infra, AI/ML) with new background and text colors
- **GitHub stats cards**: Refreshed the appearance of stats, top languages, and streak cards with the new color scheme
- **Social links**: Updated all contact and social media badge colors to match the new theme
- **New visual element**: Added `rain.svg` - an animated red rain effect with 55+ falling raindrops and a secondary layer for depth, creating a dramatic visual accent to the profile

## Implementation Details
- All color changes maintain contrast and readability while creating a more cohesive dark red aesthetic
- The rain animation uses CSS keyframes with staggered durations (0.8s-1.4s) and delays for a natural falling effect
- Border colors updated to complementary dark red shades (`#3D0000`) for consistency
- The animated rain SVG is embedded directly in the README for seamless integration

https://claude.ai/code/session_012TqdprhQpckbor2Dbp4bQ4